### PR TITLE
feat(userServiceControllers) : add user profile management endpoints

### DIFF
--- a/userService/src/main/java/com/userServiceCrudOps/springbootcrudeUserService/controller/UserProfileController.java
+++ b/userService/src/main/java/com/userServiceCrudOps/springbootcrudeUserService/controller/UserProfileController.java
@@ -28,9 +28,15 @@ public class UserProfileController {
     }
 
      @GetMapping("/getUserProfileByUsername/{username}")
-    public UserProfile findUserProfileByUsername(@PathVariable String username) {
-        return service.getUserProfileByUsername(username);
+     public UserProfile findUserProfileByUsername(@PathVariable String username) {
+         return service.getUserProfileByUsername(username);
+     }
+    
+     @PutMapping("/updateUserProfile")
+    public UserProfile updateUserProfile(@RequestBody UserProfile userProfile) {
+        return service.updateUserProfile(userProfile);
     }
+
 
 
 

--- a/userService/src/main/java/com/userServiceCrudOps/springbootcrudeUserService/controller/UserProfileController.java
+++ b/userService/src/main/java/com/userServiceCrudOps/springbootcrudeUserService/controller/UserProfileController.java
@@ -18,4 +18,9 @@ public class UserProfileController {
     public UserProfile addUserProfile(@RequestBody UserProfile userProfile) {
         return service.saveUserProfile(userProfile);
     }
+     @PostMapping("/addUserProfiles")
+    public List<UserProfile> addUserProfiles(@RequestBody List<UserProfile> userProfiles) {
+        return service.saveUserProfiles(userProfiles);
+    }
+
 }

--- a/userService/src/main/java/com/userServiceCrudOps/springbootcrudeUserService/controller/UserProfileController.java
+++ b/userService/src/main/java/com/userServiceCrudOps/springbootcrudeUserService/controller/UserProfileController.java
@@ -1,0 +1,21 @@
+package com.userServiceCrudOps.springbootcrudeUserService.controller;
+
+import com.userServiceCrudOps.springbootcrudeUserService.entity.UserProfile;
+import com.userServiceCrudOps.springbootcrudeUserService.service.UserProfileService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/user")
+public class UserProfileController {
+
+    @Autowired
+    private UserProfileService service;
+
+    @PostMapping("/addUserProfile")
+    public UserProfile addUserProfile(@RequestBody UserProfile userProfile) {
+        return service.saveUserProfile(userProfile);
+    }
+}

--- a/userService/src/main/java/com/userServiceCrudOps/springbootcrudeUserService/controller/UserProfileController.java
+++ b/userService/src/main/java/com/userServiceCrudOps/springbootcrudeUserService/controller/UserProfileController.java
@@ -33,9 +33,15 @@ public class UserProfileController {
      }
     
      @PutMapping("/updateUserProfile")
-    public UserProfile updateUserProfile(@RequestBody UserProfile userProfile) {
-        return service.updateUserProfile(userProfile);
+     public UserProfile updateUserProfile(@RequestBody UserProfile userProfile) {
+         return service.updateUserProfile(userProfile);
+     }
+    
+      @DeleteMapping("/deleteUserProfile/{id}")
+    public String deleteUserProfile(@PathVariable int id) {
+        return service.deleteUserProfile(id);
     }
+
 
 
 

--- a/userService/src/main/java/com/userServiceCrudOps/springbootcrudeUserService/controller/UserProfileController.java
+++ b/userService/src/main/java/com/userServiceCrudOps/springbootcrudeUserService/controller/UserProfileController.java
@@ -19,8 +19,13 @@ public class UserProfileController {
         return service.saveUserProfile(userProfile);
     }
      @PostMapping("/addUserProfiles")
-    public List<UserProfile> addUserProfiles(@RequestBody List<UserProfile> userProfiles) {
-        return service.saveUserProfiles(userProfiles);
+     public List<UserProfile> addUserProfiles(@RequestBody List<UserProfile> userProfiles) {
+         return service.saveUserProfiles(userProfiles);
+     }
+    @GetMapping("/getAllUserProfiles")
+    public List<UserProfile> findAllUserProfiles() {
+        return service.getUserProfiles();
     }
+
 
 }

--- a/userService/src/main/java/com/userServiceCrudOps/springbootcrudeUserService/controller/UserProfileController.java
+++ b/userService/src/main/java/com/userServiceCrudOps/springbootcrudeUserService/controller/UserProfileController.java
@@ -27,5 +27,11 @@ public class UserProfileController {
         return service.getUserProfiles();
     }
 
+     @GetMapping("/getUserProfileByUsername/{username}")
+    public UserProfile findUserProfileByUsername(@PathVariable String username) {
+        return service.getUserProfileByUsername(username);
+    }
+
+
 
 }


### PR DESCRIPTION
This commit introduces new endpoints for managing user profiles in the UserProfileController. 
The following endpoints have been added:

1. **POST /addUserProfile**: Allows adding a single user profile.
2. **POST /addUserProfiles**: Allows adding multiple user profiles.
3. **GET /getAllUserProfiles**: Retrieves all user profiles.
4. **GET /getUserProfileByUsername/{username}**: Retrieves a user profile by username.
5. **PUT /updateUserProfile**: Updates an existing user profile.
6. **DELETE /deleteUserProfile/{id}**: Deletes a user profile by ID.
